### PR TITLE
Cargo.toml: Added .forgejo to exclude list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "AGPL-3.0-or-later"
 publish = false
 
 exclude = [
+	"/.forgejo/",
 	"/.github/",
 	"/.gitlab/",
 	"/.idea/",


### PR DESCRIPTION
**PR Type**  
- [x] Other: Cargo configuration

**Describe changes**  
Added `.forgejo` to exclude list.

**What is the current behavior?**  
The `.forgejo` folder is not excluded from the Cargo crate.

**What is the new behavior?**  
The `.forgejo` folder will now be excluded from the Cargo crate.

**How to test**  
Publish to crates.io and verify that the `.forgejo` folder is not included.

**Other information**  
Forgejo is a free software package developed in Go for version control in software development with Git.