### PR TITLE
Downgraded initial version from 0.0.1 to 0.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "RustProjectTemplate"
-version = "0.0.1"
+version = "0.0.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 publish = false


### PR DESCRIPTION
**PR Type**  
- [x] Configuration

**Describe changes**  
Downgraded the initial version from `0.0.1` to `0.0.0`.
This version makes more sense for a template as it is the default value for unspecified version and indicates that the project does not have any stable version yet.