### PR TITLE
Renamed `fastcompile` profile to `fastbuild`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ lto = false
 debug = true
 strip = "none"
 
-[profile.fastcompile]
+[profile.fastbuild]
 inherits = "dev"
 # Compilation
 codegen-units = 8192


### PR DESCRIPTION
### Types of changes
- Configuration (build)

Related: b20e44b64a582c7328e1ff8e2839f6813cac7c8c

### Description
Renamed `fastcompile` profile to `fastbuild`.